### PR TITLE
Find proper manage.py command

### DIFF
--- a/plugin/pony.vim
+++ b/plugin/pony.vim
@@ -10,7 +10,10 @@ endif
 let g:loaded_pony = 1
 
 " Configuration for "manage" script name
-let g:pony_manage_filename = "manage.py"
+if !exists('g:pony_manage_filename')
+  let g:pony_manage_filename = findfile("manage.py", ".;")
+endif
+
 " function to wrap the check on this file
 function! s:ManageExists()
   return filereadable(g:pony_manage_filename)


### PR DESCRIPTION
Modified to find the proper manage.py path command by searching up the file tree for a file named "manage.py". User plugins are able to manually override this with their own path, as the script will now check if g:pony_manage_filename is set prior to setting the value.
